### PR TITLE
Add env template and update docs

### DIFF
--- a/.codex.env.example
+++ b/.codex.env.example
@@ -1,5 +1,6 @@
 # Example environment file for Codex CLI
 # Copy this file to ~/.codex.env and fill in your own values.
+# Do NOT commit this file or `~/.codex.env` to version control.
 
 # OpenAI credentials
 OPENAI_API_KEY=

--- a/.codex.env.example
+++ b/.codex.env.example
@@ -1,0 +1,15 @@
+# Example environment file for Codex CLI
+# Copy this file to ~/.codex.env and fill in your own values.
+
+# OpenAI credentials
+OPENAI_API_KEY=
+
+# Optional messaging integration
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_WHATSAPP_FROM=
+WA_GROUP_NAME=
+
+# Default model and server port overrides
+DEFAULT_MODEL=
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ yarn-error.log*
 # env
 .env*
 !.env.example
+# Codex CLI environment
+.codex.env
 
 # package
 *.tgz

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ If you'd rather not export your credentials every time, copy `.codex.env.example
 cp .codex.env.example ~/.codex.env
 ```
 
+Make sure you do **not** commit `~/.codex.env` to version control. Add the file
+to your project's `.gitignore` if necessary.
+
 Codex loads variables from this file on startup, so you can store your `OPENAI_API_KEY` and any additional environment settings there.
 
 ### OpenAI Plus/Pro Users

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ export OPENAI_API_KEY="your-api-key-here"
 > [!NOTE]
 > This command sets the key only for your current terminal session. You can add the `export` line to your shell's configuration file (e.g., `~/.zshrc`), but we recommend setting it for the session.
 
+If you'd rather not export your credentials every time, copy `.codex.env.example` to `~/.codex.env` and fill in your own values:
+
+```bash
+cp .codex.env.example ~/.codex.env
+```
+
+Codex loads variables from this file on startup, so you can store your `OPENAI_API_KEY` and any additional environment settings there.
+
 ### OpenAI Plus/Pro Users
 
 If you have a paid OpenAI account, run the following to start the login process:


### PR DESCRIPTION
## Summary
- document `.codex.env` in README
- add `.codex.env.example` for user environment variables

## Testing
- `pnpm format`
- `pnpm test` *(fails: rawExec – abort kills entire process group)*

------
https://chatgpt.com/codex/tasks/task_e_6888427389e88327b4564ed308c264ac