### PR TITLE
Add Python helper to generate MP4 from audio + still image

### DIFF
--- a/scripts/audio_bild_till_mp4.py
+++ b/scripts/audio_bild_till_mp4.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple, Union
+
+
+def _find_ffmpeg() -> str:
+    """Returnerar sökväg till ffmpeg-binären, eller kastar ett tydligt fel."""
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+
+    # Fallback: imageio-ffmpeg (kan ge en ffmpeg-binär via Python)
+    try:
+        import imageio_ffmpeg  # type: ignore
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception as exc:
+        raise RuntimeError(
+            "Hittade ingen ffmpeg.\n\n"
+            "Lösning A (rekommenderad): installera ffmpeg och lägg i PATH.\n"
+            "  - Linux: sudo apt install ffmpeg\n"
+            "  - macOS: brew install ffmpeg\n"
+            "  - Windows: installera ffmpeg och lägg till i PATH\n\n"
+            "Lösning B: pip install imageio-ffmpeg\n"
+        ) from exc
+
+
+def audio_bild_till_mp4(
+    ljudfil: Union[str, Path],
+    bildfil: Union[str, Path],
+    utfil: Union[str, Path],
+    *,
+    fps: int = 30,
+    upplosning: Optional[Tuple[int, int]] = (1920, 1080),
+    ljud_bitrate: str = "192k",
+    overwrite: bool = True,
+) -> Path:
+    """
+    Slår ihop en ljudfil + stillbild till en MP4.
+    Bilden visas hela ljudets längd.
+
+    Parametrar:
+      - ljudfil: t.ex. "voice.mp3" / "audio.wav"
+      - bildfil: t.ex. "cover.jpg" / "still.png"
+      - utfil:   t.ex. "result.mp4"
+      - fps: videons framerate (30 standard)
+      - upplosning: (bredd, höjd) eller None för att behålla bildens storlek
+      - ljud_bitrate: t.ex. "192k"
+      - overwrite: skriv över om utfil redan finns
+
+    Returnerar:
+      Path till skapad mp4.
+    """
+    ffmpeg = _find_ffmpeg()
+
+    ljudfil = Path(ljudfil)
+    bildfil = Path(bildfil)
+    utfil = Path(utfil)
+
+    if not ljudfil.is_file():
+        raise FileNotFoundError(f"Ljudfil saknas: {ljudfil}")
+    if not bildfil.is_file():
+        raise FileNotFoundError(f"Bildfil saknas: {bildfil}")
+
+    utfil.parent.mkdir(parents=True, exist_ok=True)
+
+    # Video-filter: skala/padda till vald upplösning (om angiven),
+    # samt säkra kompatibelt pixel-format och jämna dimensioner för H.264.
+    vf_parts = []
+    if upplosning is not None:
+        w, h = upplosning
+        vf_parts += [
+            f"scale={w}:{h}:force_original_aspect_ratio=decrease",
+            f"pad={w}:{h}:(ow-iw)/2:(oh-ih)/2",
+        ]
+    vf_parts += [
+        "format=yuv420p",
+        "scale=trunc(iw/2)*2:trunc(ih/2)*2",
+    ]
+    vf = ",".join(vf_parts)
+
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        ("-y" if overwrite else "-n"),
+        "-loop",
+        "1",
+        "-framerate",
+        str(fps),
+        "-i",
+        str(bildfil),
+        "-i",
+        str(ljudfil),
+        "-vf",
+        vf,
+        "-c:v",
+        "libx264",
+        "-tune",
+        "stillimage",
+        "-c:a",
+        "aac",
+        "-b:a",
+        ljud_bitrate,
+        "-shortest",
+        "-movflags",
+        "+faststart",
+        str(utfil),
+    ]
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        stdout = (exc.stdout or "").strip()
+        msg = stderr or stdout or str(exc)
+        raise RuntimeError(f"ffmpeg misslyckades:\n{msg}") from exc
+
+    return utfil
+
+
+# Exempel:
+# audio_bild_till_mp4("ljud.mp3", "bild.jpg", "klar.mp4", upplosning=(1280, 720))

--- a/scripts/audio_bild_till_mp4.py
+++ b/scripts/audio_bild_till_mp4.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import shutil
 import subprocess
 from pathlib import Path
@@ -12,20 +13,22 @@ def _find_ffmpeg() -> str:
     if ffmpeg:
         return ffmpeg
 
-    # Fallback: imageio-ffmpeg (kan ge en ffmpeg-binär via Python)
-    try:
+    # Fallback: imageio-ffmpeg (kan ge en ffmpeg-binär via Python).
+    # Kontrollera först att paketet finns så importen inte behöver ligga i ett
+    # generellt try/except-block.
+    if importlib.util.find_spec("imageio_ffmpeg") is not None:
         import imageio_ffmpeg  # type: ignore
 
         return imageio_ffmpeg.get_ffmpeg_exe()
-    except Exception as exc:
-        raise RuntimeError(
-            "Hittade ingen ffmpeg.\n\n"
-            "Lösning A (rekommenderad): installera ffmpeg och lägg i PATH.\n"
-            "  - Linux: sudo apt install ffmpeg\n"
-            "  - macOS: brew install ffmpeg\n"
-            "  - Windows: installera ffmpeg och lägg till i PATH\n\n"
-            "Lösning B: pip install imageio-ffmpeg\n"
-        ) from exc
+
+    raise RuntimeError(
+        "Hittade ingen ffmpeg.\n\n"
+        "Lösning A (rekommenderad): installera ffmpeg och lägg i PATH.\n"
+        "  - Linux: sudo apt install ffmpeg\n"
+        "  - macOS: brew install ffmpeg\n"
+        "  - Windows: installera ffmpeg och lägg till i PATH\n\n"
+        "Lösning B: pip install imageio-ffmpeg\n"
+    )
 
 
 def audio_bild_till_mp4(


### PR DESCRIPTION
### Motivation

- Provide a small reusable utility to produce an MP4 that displays a still image for the full duration of an audio file for simple video generation and tooling tasks.
- Make ffmpeg usage robust across environments by falling back to a Python-provided ffmpeg binary when a system `ffmpeg` is not found.

### Description

- Add `scripts/audio_bild_till_mp4.py` which exposes `audio_bild_till_mp4(...)` to combine an audio file and a still image into an MP4 using `ffmpeg`.
- Implement `_find_ffmpeg()` that prefers `ffmpeg` on `PATH` and falls back to `imageio-ffmpeg.get_ffmpeg_exe()` with a clear error message if neither is available.
- Validate input files, ensure the output directory exists, assemble a video-filter chain to scale/pad and ensure H.264-compatible pixel format and even dimensions, and construct an `ffmpeg` command that uses H.264/AAC with `+faststart`.
- Run `ffmpeg` via `subprocess.run(..., capture_output=True)` and raise a `RuntimeError` containing `stderr`/`stdout` output when `ffmpeg` fails for easier debugging.

### Testing

- Ran `python -m py_compile scripts/audio_bild_till_mp4.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0443cbe18832785dbc1619f6d9989)